### PR TITLE
fix(docs): address minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ cd PiClusterFlow
    ```
 
 6. **Save the Raspberry Pi SSH Password:**
-   The `ansible/ansible.cfg` file will reference an environment variable for your SSH password so that you do not have to enter it each time you run an Ansible command. You can export this variable as follows:
+   The `ansible/hosts` file will reference an environment variable for your SSH password so that you do not have to enter it each time you run an Ansible command. You can export this variable as follows:
    ```bash
    export ANSIBLE_SSH_PASS='your_ssh_password_here'
    ```


### PR DESCRIPTION
# Summary\*

`Description`: Fix minor typo in README doc.

`Reasons for the change`: Ansible `hosts` file needs to be mentioned instead of the `ansible.cfg` file since we are no longer storing the SSH references there.

# Checklist\*

- [x] I have updated documentation where necessary
- [ ] I have commented my code, particularly in hard-to-understand areas

# This PR includes the following changes\*

- [ ] feat: New Feature or update to existing feature
- [x] fix: bug fix
- [ ] refactor: refactoring of existing code
